### PR TITLE
Fix build issue with node 0.11.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "force-gc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Force minor or full garbage collection",
   "author": "GitStar",
   "license": "MIT",

--- a/src/forcegc.cc
+++ b/src/forcegc.cc
@@ -5,13 +5,13 @@ using namespace node;
 
 NAN_METHOD(Full) {
   NanScope();
-  Isolate::GetCurrent()->RequestGarbageCollectionForTesting(Isolate::GarbageCollectionType::kFullGarbageCollection);
+  Isolate::GetCurrent()->RequestGarbageCollectionForTesting(Isolate::kFullGarbageCollection);
   NanReturnUndefined();
 }
 
 NAN_METHOD(Minor) {
   NanScope();
-  Isolate::GetCurrent()->RequestGarbageCollectionForTesting(Isolate::GarbageCollectionType::kMinorGarbageCollection);
+  Isolate::GetCurrent()->RequestGarbageCollectionForTesting(Isolate::kMinorGarbageCollection);
   NanReturnUndefined();
 }
 


### PR DESCRIPTION
Closes #1. C++11 allows enums to be given their own namespace. Guess 0.11.14
isn't using that extension during build.
